### PR TITLE
Fix: load .env file before initializing services in infra_server.py

### DIFF
--- a/src/infra_server.py
+++ b/src/infra_server.py
@@ -9,6 +9,9 @@ import uvicorn
 from akgentic.infra.server.app import create_app
 from akgentic.infra.server.settings import CommunitySettings
 from akgentic.infra.wiring import wire_community
+from dotenv import load_dotenv
+
+load_dotenv()
 
 settings = CommunitySettings(catalog_path=Path("./src/catalog"))
 services = wire_community(settings)


### PR DESCRIPTION
## Description:

### Problem
POST /teams returns 500 Internal Server Error because OPENAI_API_KEY is not available in the environment when the OpenAI provider initializes during team creation using the frontend UI.

### Root Cause
`infra_server.py`: Environment variables like OPENAI_API_KEY are never injected into the process, causing the agent actor to crash on startup with openai.OpenAIError.

### Fix
Add `load_dotenv()` before akgentic imports so all .env variables are available when services are wired. `python-dotenv` is already a dependency of `akgentic-infra`. 

Closes #8 