### PR TITLE
docs: add dual licensing and CLA note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,3 +427,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines, branch naming
 
 This project is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0)](LICENSE).
 
+> **Dual licensing & CLA** — Akgentic is available under the AGPL-3.0 open-source license. A commercial license is also planned for organizations that require alternative terms. Contact [Yuma](https://www.weareyuma.com/en/contact) for more information. External contributions will be accepted once a Contributor License Agreement (CLA) is in place. Until then, please hold off on submitting pull requests.
+


### PR DESCRIPTION
## Summary
- Add a note in the License section clarifying that Akgentic is dual-licensed (AGPL-3.0 + commercial)
- Link to Yuma (https://www.weareyuma.com/en/contact) for commercial licensing inquiries
- Indicate that external contributions will be accepted once a CLA is in place

Relates to #10