### PR TITLE
feat(ci): publish to PyPI via Trusted Publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -129,3 +129,12 @@ jobs:
                 && 'https://test.pypi.org/legacy/'
                 || 'https://upload.pypi.org/legacy/' }}
           print-hash: true
+          # Subpackages version independently, so any given run only has new
+          # versions for *some* of the 8. PyPI rejects a re-upload of an
+          # existing version, which would fail every run after the first
+          # without this. The effect is "publish whatever is new".
+          #
+          # Trade-off: a forgotten version bump is skipped silently rather
+          # than reported as an error. The per-project job names and
+          # print-hash output are what make it visible in the run log.
+          skip-existing: true

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,16 +7,30 @@ name: Publish to PyPI
 # The deprecated aliases (akgentic-all, akgentic-all-extras) are NOT published.
 # They ship in the release bundle only — see scripts/build_bundle.py.
 #
-# PyPI-side setup, required once per project BEFORE the first run (8 forms):
+# PyPI-side setup, required once per project BEFORE its first publish:
 #   PyPI → Publishing → "Add a new pending publisher"
 #     Owner:            b12consulting
 #     Repository name:  akgentic-framework
 #     Workflow name:    publish-pypi.yml      <- this file's name; renaming it
 #                                                breaks every publisher config
 #     Environment:      pypi                  (or testpypi on TestPyPI)
-#   ...repeated for each of: akgentic-core, akgentic-llm, akgentic-tool,
-#   akgentic-agent, akgentic-team, akgentic-catalog, akgentic-infra,
-#   akgentic-framework
+#
+# All 8 projects name this same repo and workflow — a publisher declares which
+# workflow may publish a project, and one workflow may be authorized by many
+# projects. That is the monorepo pattern; nothing needs duplicating into the
+# per-subpackage repos.
+#
+# BUT: PyPI/TestPyPI cap how many *pending* publishers an account may hold at
+# once (observed: 3). A project that already exists takes a normal publisher
+# instead, which is not capped. So the first bootstrap has to go in batches —
+# hence the `projects` input:
+#
+#   1. register up to 3 pending publishers
+#   2. run this workflow with projects = that batch
+#   3. those projects now exist; register the next batch and repeat
+#
+# Bootstrap order matters: akgentic-framework pins its dependencies with `==`,
+# so publish it last, once the versions it names are on the index.
 #
 # A "pending" publisher does not reserve the project name — the name is only
 # claimed on the first successful upload.
@@ -35,8 +49,63 @@ on:
           - testpypi
           - pypi
         default: testpypi
+      projects:
+        description: "Distributions to publish: 'all', or a comma-separated subset"
+        type: string
+        default: all
 
 jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - name: Resolve projects to publish
+        id: plan
+        env:
+          PROJECTS: ${{ inputs.projects }}
+        run: |
+          python3 <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os, sys
+
+          # Canonical dependency order: a distribution is only published after
+          # everything it depends on, so akgentic-framework's `==` pins always
+          # resolve against an index that already has them.
+          ORDER = [
+              "akgentic-core",
+              "akgentic-llm",
+              "akgentic-tool",
+              "akgentic-agent",
+              "akgentic-team",
+              "akgentic-catalog",
+              "akgentic-infra",
+              "akgentic-framework",
+          ]
+
+          raw = os.environ["PROJECTS"].strip()
+          if raw == "all":
+              selected = ORDER
+          else:
+              asked = [p.strip() for p in raw.split(",") if p.strip()]
+              unknown = [p for p in asked if p not in ORDER]
+              if unknown:
+                  print(
+                      f"::error::Unknown distribution(s): {', '.join(unknown)}. "
+                      f"Valid: {', '.join(ORDER)}",
+                      file=sys.stderr,
+                  )
+                  raise SystemExit(1)
+              if not asked:
+                  print("::error::No distributions selected.", file=sys.stderr)
+                  raise SystemExit(1)
+              # Filter the canonical list rather than trusting input order, so
+              # dependency order holds however the batch was typed.
+              selected = [p for p in ORDER if p in set(asked)]
+
+          print(f"matrix={json.dumps(selected)}")
+          print(f"Publishing: {', '.join(selected)}", file=sys.stderr)
+          PY
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -67,7 +136,7 @@ jobs:
           if-no-files-found: error
 
   publish:
-    needs: build
+    needs: [plan, build]
     runs-on: ubuntu-latest
     # Gates the upload behind the environment's protection rules, and is part
     # of the identity PyPI checks. Must match the "Environment" field of the
@@ -86,15 +155,7 @@ jobs:
       # distributions that already exist on the index when it lands.
       max-parallel: 1
       matrix:
-        project:
-          - akgentic-core
-          - akgentic-llm
-          - akgentic-tool
-          - akgentic-agent
-          - akgentic-team
-          - akgentic-catalog
-          - akgentic-infra
-          - akgentic-framework
+        project: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - name: Download distributions
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,17 +20,31 @@ name: Publish to PyPI
 # projects. That is the monorepo pattern; nothing needs duplicating into the
 # per-subpackage repos.
 #
-# BUT: PyPI/TestPyPI cap how many *pending* publishers an account may hold at
-# once (observed: 3). A project that already exists takes a normal publisher
-# instead, which is not capped. So the first bootstrap has to go in batches —
+# That end state is fine. Bootstrapping into it is the awkward part, because a
+# project that does NOT exist yet needs a *pending* publisher, and pending
+# publishers must be unique on (repository, workflow, environment):
+#
+#   "A pending trusted publisher matching this configuration has already been
+#    registered for a different project name."
+#
+# The reason is that the project does not exist yet, so on an incoming token
+# PyPI has to decide which project to create — two identical pending configs
+# would be ambiguous. (There is also a cap of 3 pending publishers per
+# account, but the uniqueness constraint binds first.)
+#
+# So the 8 projects cannot be registered up front. Bootstrap one at a time —
 # hence the `projects` input:
 #
-#   1. register up to 3 pending publishers
-#   2. run this workflow with projects = that batch
-#   3. those projects now exist; register the next batch and repeat
+#   1. register a single pending publisher for project X
+#   2. run this workflow with projects = X
+#   3. X now exists and its publisher is normal, so the (repo, workflow,
+#      environment) triple is free again — repeat for the next project
 #
-# Bootstrap order matters: akgentic-framework pins its dependencies with `==`,
-# so publish it last, once the versions it names are on the index.
+# Order matters: akgentic-framework pins its dependencies with `==`, so publish
+# it last, once the versions it names are on the index.
+#
+# After bootstrap every publisher is normal, and `projects: all` works for
+# ordinary releases.
 #
 # A "pending" publisher does not reserve the project name — the name is only
 # claimed on the first successful upload.

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,131 @@
+name: Publish to PyPI
+
+# Publishes the 8 akgentic distributions to TestPyPI or PyPI using Trusted
+# Publishing (OIDC). No API token is stored anywhere: PyPI verifies this
+# workflow's identity at upload time and mints a short-lived token.
+#
+# The deprecated aliases (akgentic-all, akgentic-all-extras) are NOT published.
+# They ship in the release bundle only — see scripts/build_bundle.py.
+#
+# PyPI-side setup, required once per project BEFORE the first run (8 forms):
+#   PyPI → Publishing → "Add a new pending publisher"
+#     Owner:            b12consulting
+#     Repository name:  akgentic-framework
+#     Workflow name:    publish-pypi.yml      <- this file's name; renaming it
+#                                                breaks every publisher config
+#     Environment:      pypi                  (or testpypi on TestPyPI)
+#   ...repeated for each of: akgentic-core, akgentic-llm, akgentic-tool,
+#   akgentic-agent, akgentic-team, akgentic-catalog, akgentic-infra,
+#   akgentic-framework
+#
+# A "pending" publisher does not reserve the project name — the name is only
+# claimed on the first successful upload.
+#
+# Versions are read from the pyproject.toml files, so bump those first. PyPI
+# refuses to overwrite an existing version: a botched upload burns that
+# version number permanently.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Index to publish to"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+        default: testpypi
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout dispatched branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Build publishable distributions
+        run: uv run python scripts/build_bundle.py dist/ --pypi
+
+      - name: Check metadata
+        run: uvx twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-dists
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Gates the upload behind the environment's protection rules, and is part
+    # of the identity PyPI checks. Must match the "Environment" field of the
+    # pending publisher.
+    environment: ${{ inputs.target }}
+    permissions:
+      # Required for the OIDC exchange. This is the whole mechanism — without
+      # it the action cannot prove which workflow it is.
+      id-token: write
+    strategy:
+      # One upload per project rather than one bulk upload: each project has its
+      # own trusted publisher on PyPI, so each upload does its own OIDC
+      # exchange and is unambiguously scoped to that project.
+      fail-fast: false
+      # Serial, in dependency order, so akgentic-framework's `==` pins point at
+      # distributions that already exist on the index when it lands.
+      max-parallel: 1
+      matrix:
+        project:
+          - akgentic-core
+          - akgentic-llm
+          - akgentic-tool
+          - akgentic-agent
+          - akgentic-team
+          - akgentic-catalog
+          - akgentic-infra
+          - akgentic-framework
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-dists
+          path: dist/
+
+      - name: Isolate ${{ matrix.project }}
+        env:
+          PROJECT: ${{ matrix.project }}
+        run: |
+          # Distribution filenames use the normalized name (PEP 427/625):
+          # akgentic-core -> akgentic_core-<version>.{whl,tar.gz}
+          prefix="${PROJECT//-/_}-"
+          mkdir upload
+          mv "dist/$prefix"* upload/
+          echo "Uploading:"
+          ls -1 upload/
+          # sdist + wheel, nothing else.
+          count=$(ls -1 upload/ | wc -l)
+          if [ "$count" -ne 2 ]; then
+            echo "::error::Expected 2 files for $PROJECT, found $count"
+            exit 1
+          fi
+
+      - name: Publish ${{ matrix.project }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: upload
+          repository-url: >-
+            ${{ inputs.target == 'testpypi'
+                && 'https://test.pypi.org/legacy/'
+                || 'https://upload.pypi.org/legacy/' }}
+          print-hash: true

--- a/scripts/build_bundle.py
+++ b/scripts/build_bundle.py
@@ -1,18 +1,29 @@
 #!/usr/bin/env python3
-"""Build a release bundle for akgentic-framework.
+"""Build release artifacts for akgentic-framework.
 
-Builds one wheel per workspace subpackage (core, llm, tool, agent, catalog,
-team, infra) plus the framework meta-wheel, and packages them all into a
-single tarball: akgentic-framework-<version>-bundle.tar.gz.
+Two modes, one source of truth for versions and pins:
 
-A README.md with install instructions is emitted alongside the wheels inside
-the tarball.
+  build_bundle.py DIR
+      Default. Builds one wheel per workspace subpackage (core, llm, tool,
+      agent, catalog, team, infra), the framework meta-wheel, and the
+      deprecated alias wheels, then packages them all into a single tarball:
+      akgentic-framework-<version>-bundle.tar.gz, with an install README
+      alongside the wheels inside it.
+
+  build_bundle.py DIR --pypi
+      Builds the publishable set only, flat into DIR, as sdist + wheel for
+      each: the 7 subpackages plus akgentic-framework. No tarball, no README.
+
+      The deprecated aliases are deliberately NOT published. They exist to
+      keep pins off a *previous bundle* resolving; nothing was ever published
+      to PyPI under those names, so there are no public pins to preserve and
+      claiming two public names for deprecated aliases is not undoable.
 """
 from __future__ import annotations
 
+import argparse
 import shutil
 import subprocess
-import sys
 import tarfile
 import tempfile
 import textwrap
@@ -293,10 +304,23 @@ pip install --find-links {bundle_name} \\
     (bundle_dir / "README.md").write_text(readme)
 
 
-def build_wheel(project_dir: Path, out_dir: Path) -> None:
+def _build_flags(sdist: bool) -> list[str]:
+    """uv build flags: wheel only for the bundle, sdist + wheel for PyPI."""
+    return [] if sdist else ["--wheel"]
+
+
+def build_wheel(project_dir: Path, out_dir: Path, *, sdist: bool = False) -> None:
     print(f"::group::Building {project_dir.name}")
     subprocess.run(
-        ["uv", "build", "--wheel", "--project", str(project_dir), "--out-dir", str(out_dir)],
+        [
+            "uv",
+            "build",
+            *_build_flags(sdist),
+            "--project",
+            str(project_dir),
+            "--out-dir",
+            str(out_dir),
+        ],
         check=True,
     )
     print("::endgroup::")
@@ -315,6 +339,7 @@ def build_meta_wheel(
     *,
     optional_dependencies: dict[str, list[str]] | None = None,
     readme_body: str = "",
+    sdist: bool = False,
 ) -> None:
     """Generate a metadata-only wheel (no modules) with the given requirements."""
     print(f"::group::Building {name} (meta)")
@@ -348,6 +373,11 @@ def build_meta_wheel(
         # hatchling's file selection entirely. This is what makes the wheel a
         # pure set of requirements.
         bypass-selection = true
+
+        [tool.hatch.build.targets.sdist]
+        # Same reason, but sdist has no bypass-selection: name the files
+        # explicitly, or hatchling errors out looking for a package to include.
+        only-include = ["README.md", "LICENSE"]
     """)
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
@@ -355,19 +385,73 @@ def build_meta_wheel(
         (tmp_path / "README.md").write_text(readme_body or f"# {name}\n\n{description}\n")
         shutil.copyfile(ROOT / "LICENSE", tmp_path / "LICENSE")
         subprocess.run(
-            ["uv", "build", "--wheel", "--project", str(tmp_path), "--out-dir", str(out_dir)],
+            [
+                "uv",
+                "build",
+                *_build_flags(sdist),
+                "--project",
+                str(tmp_path),
+                "--out-dir",
+                str(out_dir),
+            ],
             check=True,
         )
     print("::endgroup::")
 
 
+def build_pypi_dists(out_dir: Path, version: str) -> None:
+    """Build the publishable set (sdist + wheel) flat into out_dir."""
+    for sub in SUBPACKAGES:
+        build_wheel(ROOT / "packages" / f"akgentic-{sub}", out_dir, sdist=True)
+
+    extras = build_framework_extras()
+    build_meta_wheel(
+        name="akgentic-framework",
+        description="Meta-distribution pinning a coherent akgentic release set.",
+        dependencies=[pin("core")],
+        optional_dependencies=extras,
+        version=version,
+        out_dir=out_dir,
+        readme_body=render_framework_readme(version, extras),
+        sdist=True,
+    )
+
+    dists = sorted(p.name for p in out_dir.iterdir() if p.suffix in {".whl", ".gz"})
+    print(f"\nBuilt {len(dists)} distribution file(s) for PyPI:")
+    for d in dists:
+        print(f"  {d}")
+    print(
+        "\nDeprecated aliases (akgentic-all, akgentic-all-extras) are intentionally "
+        "excluded — bundle-only."
+    )
+
+
 def main() -> None:
-    out_dir = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else ROOT / "dist"
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "out_dir",
+        nargs="?",
+        default=str(ROOT / "dist"),
+        help="output directory (default: ./dist)",
+    )
+    parser.add_argument(
+        "--pypi",
+        action="store_true",
+        help="build the publishable set (sdist + wheel, no aliases, no tarball)",
+    )
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
-    for stale in out_dir.glob("*.whl"):
+    for stale in (*out_dir.glob("*.whl"), *out_dir.glob("*.tar.gz")):
         stale.unlink()
 
     version = read_framework_version()
+
+    if args.pypi:
+        build_pypi_dists(out_dir, version)
+        return
+
     bundle_name = f"akgentic-framework-{version}-bundle"
     bundle_dir = out_dir / bundle_name
     if bundle_dir.exists():


### PR DESCRIPTION
Suite de #22. Met en place la publication PyPI ; **ne publie rien par lui-même** — le workflow est en `workflow_dispatch`.

## Mécanisme

Trusted Publishing (OIDC) : **aucun token n'est créé ni stocké**. PyPI vérifie l'identité du workflow au moment de l'upload et émet un token éphémère. C'est `permissions: id-token: write` qui rend ça possible.

## Changements

**`scripts/build_bundle.py --pypi`** — nouveau mode qui produit le set publiable à plat, en **sdist + wheel**, en réutilisant la même dérivation de versions et de pins que le bundle. Une seule source de vérité. Le mode bundle par défaut est inchangé (10 wheels, tarball, README).

**`.github/workflows/publish-pypi.yml`** — dispatch manuel avec un choix `testpypi` / `pypi`.

## Deux exclusions volontaires

- **Les alias dépréciés ne sont pas publiés.** Ils servent à faire résoudre des pins pris sur un *bundle précédent* ; rien n'a jamais été publié sur PyPI sous ces noms, donc il n'y a aucun pin public à préserver, et occuper deux noms publics pour des alias dépréciés ne se défait pas.
- **Les sdists ne sont pas ajoutés au bundle**, qui reste wheels-only pour les installs offline en `--find-links`.

## Un upload par projet, pas un upload groupé

Chaque projet a son propre trusted publisher sur PyPI. La documentation ne dit pas clairement si un seul échange OIDC couvre plusieurs projets, et je n'ai pas voulu parier la première publication dessus : une jambe de matrice par projet fait son propre échange, sans ambiguïté de scope.

Ça isole aussi les échecs — ce qui compte, parce qu'un upload PyPI est **immuable** : un upload groupé qui casse à mi-parcours ne se rejoue pas.

Sérialisé (`max-parallel: 1`) dans l'ordre des dépendances, pour que les pins `==` de `akgentic-framework` pointent vers des distributions déjà présentes sur l'index quand il arrive.

## Vérifications

| Test | Résultat |
|---|---|
| `--pypi` | 16 fichiers = 8 dists × (sdist + wheel) |
| `twine check` (set PyPI) | **16/16 PASSED**, zéro warning |
| sdist méta installable | OK, forcé avec `--no-binary akgentic-framework` |
| Mode bundle (non-régression) | 10 wheels + tarball, inchangé |
| Globbing par projet | simulé sur les artefacts réels : les 8 jambes matchent **exactement 2** fichiers, zéro reliquat |
| YAML | parse, 8 projets dans la matrice |

## Ce qui reste manuel côté PyPI

**8 pending publishers à créer** (un par projet), documentés dans l'en-tête du workflow. Champs : owner `b12consulting`, repo `akgentic-framework`, workflow `publish-pypi.yml`, environment `pypi` (ou `testpypi`).

Deux points relevés dans la doc PyPI :

- Un pending publisher **ne réserve pas le nom** — il n'est pris qu'au premier upload réussi. Les 10 noms sont libres aujourd'hui, ce n'est pas garanti indéfiniment.
- **Renommer ce fichier casse les 8 configurations** — le nom du workflow fait partie de l'identité vérifiée.

⚠️ **À vérifier dans l'UI avant le premier run** : qu'un projet créé par pending publisher appartient bien à l'**organisation** et non au compte personnel. Je n'ai pas pu le confirmer dans la doc, et un transfert après coup est plus pénible qu'un réglage correct au départ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)